### PR TITLE
Added the CombinedOutput function to allow both stdout and stderr to be collected

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -128,3 +128,19 @@ func (s *Session) Output() (out []byte, err error) {
 	out = stdout.Bytes()
 	return
 }
+
+func (s *Session) CombinedOutput() (out []byte, err error) {
+	oldout := s.Stdout
+	olderr := s.Stderr
+	defer func() {
+		s.Stdout = oldout
+		s.Stderr = olderr
+	}()
+	stdout := bytes.NewBuffer(nil)
+	s.Stdout = stdout
+	s.Stderr = stdout
+
+	err = s.Run()
+	out = stdout.Bytes()
+	return
+}

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"testing"
 	"time"
+	"strings"
 )
 
 func TestUnmarshalJSON(t *testing.T) {
@@ -93,5 +94,16 @@ func TestSetTimeout(t *testing.T) {
 	err := s.Command("sleep", "2").Run()
 	if err != ErrExecTimeout {
 		t.Fatal(err)
+	}
+}
+
+func TestCombinedOutput(t *testing.T) {
+	bytes, err := s.Command("sh", "-c", "echo stderr >&2 ; echo stdout").CombinedOutput()
+	if err != nil {
+		t.Error(err)
+	}
+	stringOutput := string(bytes)
+	if ! (strings.Contains(stringOutput, "stdout") && strings.Contains(stringOutput, "stderr")) {
+		t.Errorf("expect output from both output streams, got '%s'", strings.TrimSpace(stringOutput))
 	}
 }


### PR DESCRIPTION
I wanted all the output from psql to be logged, but could only capture the stdout. I just copied the Output function and added stderr.