### PR TITLE
Write debugging command output to Stdout rather than Stderr

### DIFF
--- a/sh.go
+++ b/sh.go
@@ -58,7 +58,7 @@ type Session struct {
 func (s *Session) writePrompt(args ...interface{}) {
 	var ps1 = fmt.Sprintf("[golang-sh]$")
 	args = append([]interface{}{ps1}, args...)
-	fmt.Fprintln(s.Stderr, args...)
+	fmt.Fprintln(s.Stdout, args...)
 }
 
 func NewSession() *Session {


### PR DESCRIPTION
Currently when `ShowCmd` is enabled, the command prompt is written to the Stderr.  This can be misleading because the commands are not actually errors.  Instead, they should be written to the Stdout.