### PR TITLE
Add method to write stdout to file.

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -131,7 +131,7 @@ func (s *Session) Output() (out []byte, err error) {
 	return
 }
 
-func (s *Session) WriteOutput(f string) error {
+func (s *Session) WriteStdout(f string) error {
 	oldout := s.Stdout
 	defer func() {
 		s.Stdout = oldout

--- a/pipe.go
+++ b/pipe.go
@@ -131,6 +131,21 @@ func (s *Session) Output() (out []byte, err error) {
 	return
 }
 
+func (s *Session) WriteOutput(f string) error {
+	oldout := s.Stdout
+	defer func() {
+		s.Stdout = oldout
+	}()
+
+	out, err := os.Create(f)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	s.Stdout = out
+	return s.Run()
+}
+
 func (s *Session) CombinedOutput() (out []byte, err error) {
 	oldout := s.Stdout
 	olderr := s.Stderr


### PR DESCRIPTION
I would like to write output to file directly instead of copying []byte to memory first. Example:
`docker save debian:8.6 > /tmp/debian.tar`

ref: http://stackoverflow.com/a/18987147